### PR TITLE
Add Brand and Thin icon style

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ echo $this->FontAwe->solid('receipt'); // <i class="fas fa-receipt"></i>
 echo $this->FontAwe->regular('receipt', 'Title'); // <i class="far fa-receipt"></i> Title
 echo $this->FontAwe->light('receipt'); // <i class="fal fa-receipt"></i>
 echo $this->FontAwe->duo('receipt'); // <i class="fad fa-receipt"></i>
+echo $this->FontAwe->brand('github'); // <i class="fab fa-github"></i>
+echo $this->FontAwe->thin('receipt'); // <i class="fat fa-receipt"></i>
 
 ```
 
@@ -46,11 +48,15 @@ echo $this->FontAwe->icon('fas', 'receipt'); // <i class="fas fa-receipt"></i>
 echo $this->FontAwe->icon('far', 'receipt', 'Title'); // <i class="far fa-receipt"></i> Title
 echo $this->FontAwe->icon('fal', 'receipt'); // <i class="fal fa-receipt"></i>
 echo $this->FontAwe->icon('fad', 'receipt'); // <i class="fad fa-receipt"></i>
+echo $this->FontAwe->icon('fab', 'github'); // <i class="fab fa-github"></i>
+echo $this->FontAwe->icon('fat', 'receipt'); // <i class="fat fa-receipt"></i>
 
 echo $this->FontAwe->icon(FontAweHelper::SOLID, 'receipt'); // <i class="fas fa-receipt"></i>
 echo $this->FontAwe->icon(FontAweHelper::REGULAR, 'receipt', 'Title'); // <i class="far fa-receipt"></i> Title
 echo $this->FontAwe->icon(FontAweHelper::LIGHT, 'receipt'); // <i class="fal fa-receipt"></i>
 echo $this->FontAwe->icon(FontAweHelper::DUO, 'receipt'); // <i class="fad fa-receipt"></i>
+echo $this->FontAwe->icon(FontAweHelper::BRAND, 'github'); // <i class="fab fa-github"></i>
+echo $this->FontAwe->icon(FontAweHelper::THIN, 'receipt'); // <i class="fat fa-receipt"></i>
 
 ```
 

--- a/src/View/Helper/FontAweHelper.php
+++ b/src/View/Helper/FontAweHelper.php
@@ -33,6 +33,16 @@ class FontAweHelper extends Helper
     public const DUO = 'fad';
 
     /**
+     * FontAwesome Brand icon type
+     */
+    public const BRAND = 'fab';
+
+    /**
+     * FontAwesome Thin icon type
+     */
+    public const THIN = 'fat';
+
+    /**
      * Base link for getting a FontAwesome kit. Kit identifier will be added by using sprintf()
      */
     public const KIT_URL = 'https://kit.fontawesome.com/%s.js';
@@ -164,6 +174,60 @@ class FontAweHelper extends Helper
     public function duoLink(string $icon, $url, ?string $title = '', array $options = []): string
     {
         return $this->link(self::DUO, $icon, $url, $title, $options);
+    }
+
+    /**
+     * Create a FontAwesome Brand icon with optional title appended
+     *
+     * @param string $icon FontAwesome icon
+     * @param string|null $title Anchor text
+     * @param array $options Attributes to pass to icon element <i />
+     * @return string Finished FontAwesome Brand icon and optional title
+     */
+    public function brand(string $icon, ?string $title = '', array $options = []): string
+    {
+        return $this->icon(self::BRAND, $icon, $title, $options);
+    }
+
+    /**
+     * Create a link with a Brand icon
+     *
+     * @param string $icon FontAwesome icon
+     * @param string|array $url Html url as string or array
+     * @param string|null $title Anchor text included with icon
+     * @param array $options Attributes to pass to anchor element (pass icon attributes through $options['icon'])
+     * @return string Finished anchor element with FontAwesome Brand icon and title
+     */
+    public function brandLink(string $icon, $url, ?string $title = '', array $options = []): string
+    {
+        return $this->link(self::BRAND, $icon, $url, $title, $options);
+    }
+
+    /**
+     * Create a FontAwesome Thin icon with optional title appended
+     *
+     * @param string $icon FontAwesome icon
+     * @param string|null $title Anchor text
+     * @param array $options Attributes to pass to icon element <i />
+     * @return string Finished FontAwesome Thin icon and optional title
+     */
+    public function thin(string $icon, ?string $title = '', array $options = []): string
+    {
+        return $this->icon(self::THIN, $icon, $title, $options);
+    }
+
+    /**
+     * Create a link with a Thin icon
+     *
+     * @param string $icon FontAwesome icon
+     * @param string|array $url Html url as string or array
+     * @param string|null $title Anchor text included with icon
+     * @param array $options Attributes to pass to anchor element (pass icon attributes through $options['icon'])
+     * @return string Finished anchor element with FontAwesome Thin icon and title
+     */
+    public function thinLink(string $icon, $url, ?string $title = '', array $options = []): string
+    {
+        return $this->link(self::THIN, $icon, $url, $title, $options);
     }
 
     /**

--- a/tests/TestCase/View/Helper/FontAweHelperTest.php
+++ b/tests/TestCase/View/Helper/FontAweHelperTest.php
@@ -165,6 +165,34 @@ class FontAweHelperTest extends TestCase
     }
 
     /**
+     * Test brandLink method
+     *
+     * @return void
+     * @uses \Avolle\FontAwesome\View\Helper\FontAweHelper::brandLink()
+     * @noinspection HtmlUnknownTarget
+     */
+    public function testBrandLink(): void
+    {
+        $expected = '<a href="/link"><i class="fab fa-github"></i> Some Title</a>';
+        $actual = $this->FontAwe->brandLink('github', '/link', 'Some Title');
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test thinLink method
+     *
+     * @return void
+     * @uses \Avolle\FontAwesome\View\Helper\FontAweHelper::thinLink()
+     * @noinspection HtmlUnknownTarget
+     */
+    public function testThinLink(): void
+    {
+        $expected = '<a href="/link"><i class="fat fa-receipt"></i> Some Title</a>';
+        $actual = $this->FontAwe->thinLink('receipt', '/link', 'Some Title');
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
      * Test link method
      * Empty title
      *


### PR DESCRIPTION
This PR adds methods to support the `brand` and the new `thin` icon style released in FontAwesome v6.0.0.