### PR TITLE
Add support for Cake 5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.0', '8.1']
+        php-version: ['8.1']
     name: PHP ${{ matrix.php-version }}
 
     steps:
@@ -29,11 +29,7 @@ jobs:
 
     - name: Composer install
       run: |
-        if [[ ${{ matrix.php-version }} == '8.0' ]]; then
-          composer install --ignore-platform-reqs
-        else
           composer install
-        fi
 
     - name: Run PHPUnit
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Thumbs.db
 composer.lock
 # PHPUnit
 .phpunit.result.cache
+.phpunit.cache
 # vim
 *~
 *.swp

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Create FontAwesome icons with a CakePHP helper
 
 NB! FontAwesome scripts not included in plugin. You can use FontAwesome kits without downloading assets. See further down.
 
-Works with:
-Type | Version
----- | ----
-CakePHP | ^4.2
-PHP | ^7.4 \| ^8.0
+## Version map:
+| Plugin | Branch | Cake | PHP |
+|--------| ------ | --- | --- |
+| 2.x    | main | 5.x | ^8.1 |
+| 1.x    | 1.x | 4.x | ^7.4 \| ^8.0 |
 
-Supports these Fonts:
+## Supports these Fonts:
 * Solid
 * Regular
 * Light

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     },
     "require": {
         "php": "^8.1",
-        "cakephp/cakephp": "^5.x-dev@dev"
+        "cakephp/cakephp": "^5.0.0"
     },
     "require-dev": {
-        "cakephp/cakephp-codesniffer": "^4.4",
-        "phpstan/phpstan": "^1.2",
-        "phpunit/phpunit": "^9.5"
+        "cakephp/cakephp-codesniffer": "^5.0.0",
+        "phpstan/phpstan": "^1.10.33",
+        "phpunit/phpunit": "^10.3.3"
     },
     "autoload": {
         "psr-4": {
@@ -52,7 +52,7 @@
         "test": "phpunit --colors=always"
     },
     "prefer-stable": true,
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "config": {
         "sort-packages": true,
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -32,13 +32,19 @@
     "autoload": {
         "psr-4": {
             "Avolle\\FontAwesome\\": "src/"
-        }
+        },
+        "files": [
+            "vendor/cakephp/cakephp/src/Core/functions_global.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {
             "Avolle\\FontAwesome\\Test\\": "tests/",
             "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
-        }
+        },
+        "files": [
+            "vendor/cakephp/cakephp/src/Core/functions_global.php"
+        ]
     },
     "scripts": {
         "check": [

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "source": "https://github.com/mentisy/cakephp-font-awesome"
     },
     "require": {
-        "php": "^7.4|^8.0",
-        "cakephp/cakephp": "^4.2"
+        "php": "^8.1",
+        "cakephp/cakephp": "^5.x-dev@dev"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^4.4",
@@ -52,6 +52,7 @@
         "test": "phpunit --colors=always"
     },
     "prefer-stable": true,
+    "minimum-stability": "dev",
     "config": {
         "sort-packages": true,
         "allow-plugins": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
     colors="true"
-    processIsolation="false"
-    stopOnFailure="false"
     bootstrap="tests/bootstrap.php"
 >
-    <coverage>
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
-    </coverage>
+    <coverage/>
     <php>
         <ini name="memory_limit" value="-1"/>
         <ini name="apc.enable_cli" value="1"/>
@@ -19,9 +13,14 @@
     <!-- Add any additional test suites you want to run here -->
     <testsuites>
         <testsuite name="plugin">
-            <directory>tests/TestCase/</directory>
+          <directory>tests/TestCase/</directory>
         </testsuite>
         <!-- Add plugin test suites here. -->
     </testsuites>
     <!-- Ignore vendor tests in code coverage reports -->
+    <source>
+        <include>
+          <directory>src/</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/View/Helper/FontAweHelper.php
+++ b/src/View/Helper/FontAweHelper.php
@@ -52,14 +52,14 @@ class FontAweHelper extends Helper
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [];
+    protected array $_defaultConfig = [];
 
     /**
      * List of helpers used by this helper
      *
      * @var array
      */
-    protected $helpers = ['Html'];
+    protected array $helpers = ['Html'];
 
     /**
      * Template for FontAwesome icon class attribute
@@ -85,12 +85,12 @@ class FontAweHelper extends Helper
      * Create a link with a FontAwesome Solid icon
      *
      * @param string $icon FontAwesome icon
-     * @param string|array $url Html url as string or array
+     * @param array|string $url Html url as string or array
      * @param string|null $title Anchor text included with icon
      * @param array $options Attributes to pass to anchor element (pass icon attributes through $options['icon'])
      * @return string Finished anchor element with FontAwesome Solid icon and title
      */
-    public function solidLink(string $icon, $url, ?string $title = '', array $options = []): string
+    public function solidLink(string $icon, array|string $url, ?string $title = '', array $options = []): string
     {
         return $this->link(self::SOLID, $icon, $url, $title, $options);
     }
@@ -112,12 +112,12 @@ class FontAweHelper extends Helper
      * Create a link with a FontAwesome Regular icon
      *
      * @param string $icon FontAwesome icon
-     * @param string|array $url Html url as string or array
+     * @param array|string $url Html url as string or array
      * @param string|null $title Anchor text included with icon
      * @param array $options Attributes to pass to anchor element (pass icon attributes through $options['icon'])
      * @return string Finished anchor element with FontAwesome Regular icon and title
      */
-    public function regularLink(string $icon, $url, ?string $title = '', array $options = []): string
+    public function regularLink(string $icon, array|string $url, ?string $title = '', array $options = []): string
     {
         return $this->link(self::REGULAR, $icon, $url, $title, $options);
     }
@@ -139,12 +139,12 @@ class FontAweHelper extends Helper
      * Create a link with a FontAwesome Light icon
      *
      * @param string $icon FontAwesome icon
-     * @param string|array $url Html url as string or array
+     * @param array|string $url Html url as string or array
      * @param string|null $title Anchor text included with icon
      * @param array $options Attributes to pass to anchor element (pass icon attributes through $options['icon'])
      * @return string Finished anchor element with FontAwesome Light icon and title
      */
-    public function lightLink(string $icon, $url, ?string $title = '', array $options = []): string
+    public function lightLink(string $icon, array|string $url, ?string $title = '', array $options = []): string
     {
         return $this->link(self::LIGHT, $icon, $url, $title, $options);
     }
@@ -166,12 +166,12 @@ class FontAweHelper extends Helper
      * Create a link with a Duotone icon
      *
      * @param string $icon FontAwesome icon
-     * @param string|array $url Html url as string or array
+     * @param array|string $url Html url as string or array
      * @param string|null $title Anchor text included with icon
      * @param array $options Attributes to pass to anchor element (pass icon attributes through $options['icon'])
      * @return string Finished anchor element with FontAwesome Duotone icon and title
      */
-    public function duoLink(string $icon, $url, ?string $title = '', array $options = []): string
+    public function duoLink(string $icon, array|string $url, ?string $title = '', array $options = []): string
     {
         return $this->link(self::DUO, $icon, $url, $title, $options);
     }
@@ -193,12 +193,12 @@ class FontAweHelper extends Helper
      * Create a link with a Brand icon
      *
      * @param string $icon FontAwesome icon
-     * @param string|array $url Html url as string or array
+     * @param array|string $url Html url as string or array
      * @param string|null $title Anchor text included with icon
      * @param array $options Attributes to pass to anchor element (pass icon attributes through $options['icon'])
      * @return string Finished anchor element with FontAwesome Brand icon and title
      */
-    public function brandLink(string $icon, $url, ?string $title = '', array $options = []): string
+    public function brandLink(string $icon, array|string $url, ?string $title = '', array $options = []): string
     {
         return $this->link(self::BRAND, $icon, $url, $title, $options);
     }
@@ -220,12 +220,12 @@ class FontAweHelper extends Helper
      * Create a link with a Thin icon
      *
      * @param string $icon FontAwesome icon
-     * @param string|array $url Html url as string or array
+     * @param array|string $url Html url as string or array
      * @param string|null $title Anchor text included with icon
      * @param array $options Attributes to pass to anchor element (pass icon attributes through $options['icon'])
      * @return string Finished anchor element with FontAwesome Thin icon and title
      */
-    public function thinLink(string $icon, $url, ?string $title = '', array $options = []): string
+    public function thinLink(string $icon, array|string $url, ?string $title = '', array $options = []): string
     {
         return $this->link(self::THIN, $icon, $url, $title, $options);
     }
@@ -263,13 +263,18 @@ class FontAweHelper extends Helper
      *
      * @param string $type FontAwesome icon type (solid, regular, light, duo)
      * @param string $icon FontAwesome icon
-     * @param string|array $url Anchor text
+     * @param array|string $url Anchor text
      * @param string|null $title Html url as string or array
      * @param array $options Attributes to pass to anchor element (pass icon attributes through $options['icon'])
      * @return string Finished anchor element with FontAwesome icon and title
      */
-    public function link(string $type, string $icon, $url, ?string $title = '', array $options = []): string
-    {
+    public function link(
+        string $type,
+        string $icon,
+        array|string $url,
+        ?string $title = '',
+        array $options = [],
+    ): string {
         $options += ['escape' => false];
         $title = $this->icon($type, $icon, $title, $options['icon'] ?? []);
         unset($options['icon']);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,5 +3,5 @@ declare(strict_types=1);
 
 // Load in some default App configuration, so tests don't fail
 \Cake\Core\Configure::write('App.namespace', 'App');
-\Cake\Core\Configure::write('App.encoding', 'UTF8');
+\Cake\Core\Configure::write('App.encoding', 'UTF-8');
 \Cake\Core\Configure::write('App.jsBaseUrl', 'js/');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,4 +3,5 @@ declare(strict_types=1);
 
 // Load in some default App configuration, so tests don't fail
 \Cake\Core\Configure::write('App.namespace', 'App');
+\Cake\Core\Configure::write('App.encoding', 'UTF8');
 \Cake\Core\Configure::write('App.jsBaseUrl', 'js/');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,8 @@
 declare(strict_types=1);
 
 // Load in some default App configuration, so tests don't fail
-\Cake\Core\Configure::write('App.namespace', 'App');
-\Cake\Core\Configure::write('App.encoding', 'UTF-8');
-\Cake\Core\Configure::write('App.jsBaseUrl', 'js/');
+use Cake\Core\Configure;
+
+Configure::write('App.namespace', 'App');
+Configure::write('App.encoding', 'UTF-8');
+Configure::write('App.jsBaseUrl', 'js/');


### PR DESCRIPTION
This PR adds support for CakePHP 5.x.

Changes are primarily adding types to properties and parameters.